### PR TITLE
#163047986 Setup endpoint for retrieving upcoming meetups

### DIFF
--- a/server/controller/meetup.js
+++ b/server/controller/meetup.js
@@ -38,4 +38,12 @@ export default class meetupController {
     }
     return res.status(200).json({ status: 200, data: found });
   }
+
+  static getUpcoming(req, res) {
+    const upcoming = Meetup.getUpcomingMeetup();
+    if (upcoming.length === 0) {
+      return res.status(204).json({ status: 200, data: [{ info: 'No upcoming meetup' }] });
+    }
+    return res.status(200).json({ status: 200, data: upcoming });
+  }
 }

--- a/server/route/meetup.js
+++ b/server/route/meetup.js
@@ -9,8 +9,13 @@ const router = Router();
 
 /** This router handles request for the creation of a meetup */
 router.post('/', meetupController.createMeetup);
+
 /** This router handles request to get all meetups */
 router.get('/', meetupController.getMeetups);
+
+/** This router handles request to get upcoming meetup */
+router.get('/upcoming', meetupController.getUpcoming);
+
 /** This router handles requests to get a specific meetup */
 router.get('/:meetupId', meetupController.getMeetup);
 

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -80,4 +80,21 @@ describe('TEST ALL MEETUP ENDPOINTS', () => {
         done();
       });
   });
+  /**
+   * Testing GET/api/v1/meetups/upcoming endpoint
+   */
+  it('IT SHOULD RETURN ALL UPCOMING MEETUPS', (done) => {
+    server
+      .get('/api/v1/meetups/3')
+      .set('Accept', 'application/json')
+      .expect('Content-type', /json/)
+      .expect(200)
+      .end((err, res) => {
+        res.status.should.equal(200);
+        res.body.should.be.an('object');
+        res.body.should.have.property('status', 200);
+        res.body.should.have.property('data');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
This PR sets up endpoint to retrieve upcoming meetups

#### Description of Task to be completed?
setup meetupController.getUpcoming
setup route GET/meetups/upcoming

#### How should this be manually tested?
clone the repo //#endregion
checkout to ft-Setup-GET/api/v1/meetup/upcoming-endpoint-163047986 branch
run npm start
test with postman

#### Any background context you want to provide?
Users can now retrieve upcoming meetups

#### What are the relevant pivotal tracker stories?
#163047986

#### Screenshots
no screenshots

#### Questions
can i merge?