### PR TITLE
#163047987 Setup enpoint for downvoting a question

### DIFF
--- a/server/controller/questions.js
+++ b/server/controller/questions.js
@@ -33,4 +33,13 @@ export default class questionController {
     }
     return res.status(200).json({ status: 200, data: upvote });
   }
+
+  static downvote(req, res) {
+    const { questionId } = req.params;
+    const downvote = Question.downvote(questionId);
+    if (downvote < 0) {
+      return res.status(404).json({ status: 404, error: 'This question does not exist' });
+    }
+    return res.status(200).json({ status: 200, data: downvote });
+  }
 }

--- a/server/route/questions.js
+++ b/server/route/questions.js
@@ -13,4 +13,7 @@ router.post('/', questionController.createQuestion);
 /** This routes handles request to upvote a question */
 router.patch('/:questionId/upvote', questionController.upvote);
 
+/** This route handles request to downvote a question */
+router.patch('/:questionId/downvote', questionController.downvote);
+
 export default router;

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -160,4 +160,46 @@ describe('TEST ALL QUESTION ENDPOINTS', () => {
         done();
       });
   });
+
+  it('IT SHOULD THROW AN ERROR WHEN GIVEN A NON EXISTING MEETUP', (done) => {
+    server
+      .patch('/api/v1/questions/BOY/upvote')
+      .set('Accept', 'application/json')
+      .expect('Content-type', /json/)
+      .expect(404)
+      .end((err, res) => {
+        res.status.should.equal(404);
+        res.body.should.be.an('object');
+        res.body.should.have.property('status', 404);
+        done();
+      });
+  });
+
+  it('IT SHOULD DOWNVOTE A QUESTION', (done) => {
+    server
+      .patch('/api/v1/questions/1/downvote')
+      .set('Accept', 'application/json')
+      .expect('Content-type', /json/)
+      .expect(200)
+      .end((err, res) => {
+        res.status.should.equal(200);
+        res.body.should.be.an('object');
+        res.body.should.have.property('status', 200);
+        done();
+      });
+  });
+
+  it('IT SHOULD THROW AN ERROR WHEN SENT NON EXISTING MEETUP', (done) => {
+    server
+      .patch('/api/v1/questions/wrong/downvote')
+      .set('Accept', 'application/json')
+      .expect('Content-type', /json/)
+      .expect(404)
+      .end((err, res) => {
+        res.status.should.equal(404);
+        res.body.should.be.an('object');
+        res.body.should.have.property('status', 404);
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
This PR sets up endpoint for downvoting a question

#### Description of Task to be completed?
setup questionController.downvote

#### How should this be manually tested?
clone the repo //#endregion
checkout to ft-Setup-PATCH/api/v1/questions/downvote-endpoint-163047987 branch
run npm start
test with postman

#### Any background context you want to provide?
users can now downvote a question

#### What are the relevant pivotal tracker stories?
#163047987

#### Screenshots
no screenshots

#### Questions
can i merge?